### PR TITLE
updated link to contributing guidelines page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Anonymous Chat App
  - [Copyright and License](#copyright-and-license)
 
 ## Documentation
- We require that all changes are documented clearly and concisely. Please read the [contributing guidelines](https://github.com/mtuopensource/TechChat/blob/master/CONTRIBUTING.md) for more information.
+ We require that all changes are documented clearly and concisely. Please read the [contributing guidelines](https://github.com/mtuopensource/TechChat/blob/master/.github/CONTRIBUTING.md) for more information.
 
 ## Installation
 


### PR DESCRIPTION
contributing guideline old link in Readme.md: https://github.com/mtuopensource/TechChat/blob/master/CONTRIBUTING.md
This link was giving "Page Not Found error".

actual link working: https://github.com/mtuopensource/TechChat/blob/master/.github/CONTRIBUTING.md

just found this while looking to contribute to this repo.

### Working Issue
  <!-- add the issue that your branch was working on 
     ie. #7 -->
https://github.com/mtuopensource/TechChat/blob/master/CONTRIBUTING.md
This link was giving "Page Not Found error".
 ---
 

### Changes
<!-- If your changes are large, include some of the highlights -->
- Changed link to https://github.com/mtuopensource/TechChat/blob/master/.github/CONTRIBUTING.md
---

### Extra Info
<!-- any other info deemed relevant-->
---

<!-- this lets us know that you sent a pull request -->
@ajwgeek
@I-Smith
@Ryaguy15
